### PR TITLE
Fix wrong indexing in tournament selector

### DIFF
--- a/ga_test.go
+++ b/ga_test.go
@@ -240,7 +240,7 @@ func TestGALog(t *testing.T) {
 	ga.init(NewVector)
 	ga.evolve()
 	var expected = "pop_id=QrZ min=-21.342844 max=16.086140 avg=-2.554992 std=11.673396\n" +
-		"pop_id=QrZ min=-29.052226 max=10.630133 avg=-11.827780 std=8.179576\n"
+		"pop_id=QrZ min=-29.052226 max=10.630133 avg=-11.885364 std=8.266295\n"
 	if s := b.String(); s != expected {
 		t.Errorf("Expected %s, got %s", expected, s)
 	}

--- a/selection.go
+++ b/selection.go
@@ -58,7 +58,8 @@ func (sel SelTournament) Apply(n uint, indis Individuals, rng *rand.Rand) (Indiv
 		// Find the best contestant
 		winners[i] = indis[contestants[0]]
 		winners[i].Evaluate()
-		for j, idx := range contestants[1:] {
+		winnerIdx = idxs[0]
+		for j, idx := range contestants {
 			if indis[idx].GetFitness() < winners[i].Fitness {
 				winners[i] = indis[idx]
 				indexes[i] = idx

--- a/selection_test.go
+++ b/selection_test.go
@@ -37,6 +37,41 @@ func TestSelectionSize(t *testing.T) {
 	}
 }
 
+func TestSelectionUniqueness(t *testing.T) {
+	var (
+		rng = newRand()
+		indis = newIndividuals(3, NewVector, rng)
+		selectors = []Selector{
+			SelTournament{
+				NContestants: 2,
+			},
+			SelElitism{},
+		}
+		numIterations = 500
+		anyNotUnique = false
+	)
+	for _, selector := range selectors {
+		for i := 0; i < numIterations; i++ {
+			var selected, _, _= selector.Apply(2, indis, rng)
+			var unique= false
+			var first= selected[0].Genome.(Vector)
+			var second= selected[1].Genome.(Vector)
+			for index := range first {
+				if first[index] != second[index] {
+					unique = true
+					break
+				}
+			}
+			if !unique {
+				anyNotUnique = true
+			}
+		}
+	}
+	if anyNotUnique {
+		t.Error("Selector does not guarantee unique individuals")
+	}
+}
+
 func TestSelElitism(t *testing.T) {
 	var (
 		rng      = newRand()


### PR DESCRIPTION
There is a bug in `SelTournament` where the contestants[1:] and idxs slices are of different length but use the same j index. As a result, the wrong contestant is excluded from the notSelectedIdxs slice, allowing for duplicate parents.

I wrote up a test to check for that, but it is still probabilistic and may require multiple runs of the test to confirm. `numIterations` can be tweaked to match the acceptable margin of error