### PR TITLE
Fix neighbor index in island ring model

### DIFF
--- a/individuals.go
+++ b/individuals.go
@@ -124,7 +124,7 @@ func (indis Individuals) FitMin() float64 {
 	return minFloat64s(indis.getFitnesses())
 }
 
-// FitMax returns the best fitness of a slice of individuals.
+// FitMax returns the worst fitness of a slice of individuals.
 func (indis Individuals) FitMax() float64 {
 	if indis.IsSortedByFitness() {
 		return indis[len(indis)-1].Fitness

--- a/models.go
+++ b/models.go
@@ -243,7 +243,7 @@ func (mod ModRing) Apply(pop *Population) error {
 	for i := range pop.Individuals {
 		var (
 			indi      = pop.Individuals[i].Clone(pop.RNG)
-			neighbour = pop.Individuals[i%len(pop.Individuals)]
+			neighbour = pop.Individuals[(i+1)%len(pop.Individuals)]
 		)
 		indi.Crossover(neighbour, pop.RNG)
 		// Apply mutation to the offsprings

--- a/selection.go
+++ b/selection.go
@@ -104,7 +104,7 @@ func (sel SelRoulette) Apply(n uint, indis Individuals, rng *rand.Rand) (Individ
 	)
 	for i := range selected {
 		var (
-			index  = sort.SearchFloat64s(wheel, rand.Float64())
+			index  = sort.SearchFloat64s(wheel, rng.Float64())
 			winner = indis[index]
 		)
 		indexes[i] = index


### PR DESCRIPTION
The ring model is currently crossing over each individual with itself.

I had to stare at this to make sure my eyes weren't deceiving me.

In `ModRing` [`Apply()`](https://github.com/MaxHalford/eaopt/blob/a07183a46a3e5846ec4b69628a5aec6b28d0a481/models.go#L246):

```go
var (
	indi      = pop.Individuals[i].Clone(pop.RNG)
	neighbour = pop.Individuals[i%len(pop.Individuals)]
)
indi.Crossover(neighbour, pop.RNG)
```

I guess that's supposed to be `(i+1)%len(...)`

The PR includes a couple other minor things.