### PR TITLE
Feature/implement genome marshaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.prof
 *.test
 *.pdf
+.DS_Store

--- a/diff_evo_test.go
+++ b/diff_evo_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -41,7 +42,8 @@ func ExampleDiffEvo() {
 	}
 
 	// Output best encountered solution
-	fmt.Printf("Found minimum of %.5f in %v\n", y, x)
+	os.Stderr.WriteString(fmt.Sprintf("Found minimum of %.5f in %v\n", y, x))
+	//fmt.Printf("Found MIN of %.5f in %v\n", y, x)
 	// Output:
 	// Found minimum of 0.00137 in [0.0004420129693826938 0.000195924625132926]
 }

--- a/ga.go
+++ b/ga.go
@@ -55,9 +55,6 @@ func (ga *GA) init(newGenome func(rng *rand.Rand) Genome) error {
 		if err != nil {
 			return err
 		}
-		for i := 0; i < len(ga.Populations); i++ {
-			ga.Populations[i].Individuals.Evaluate(ga.ParallelEval)
-		}
 	} else {
 		ga.Populations = make(Populations, ga.NPops)
 		for i := range ga.Populations {

--- a/ga.go
+++ b/ga.go
@@ -191,6 +191,7 @@ func (ga *GA) Minimize(newGenome func(rng *rand.Rand) Genome) error {
 	return nil
 }
 
+// Marshal marshals the GA's current populations to the `PopulationsWriter`, if present.
 func (ga *GA) Marshal() (err error) {
 	if ga.PopulationsWriter != nil {
 		if ga.GenomeJSONUnmarshaler != nil {

--- a/ga_config.go
+++ b/ga_config.go
@@ -1,7 +1,9 @@
 package eaopt
 
 import (
+	"context"
 	"errors"
+	"io"
 	"log"
 	"math/rand"
 	"time"
@@ -25,6 +27,13 @@ type GAConfig struct {
 	Callback     func(ga *GA)
 	EarlyStop    func(ga *GA) bool
 	RNG          *rand.Rand
+
+	Context context.Context
+
+	// Optional, marshaling fields
+	PopulationsReader     io.Reader
+	PopulationsWriter     io.Writer
+	GenomeJSONUnmarshaler func([]byte) (Genome, error)
 }
 
 // NewGA returns a pointer to a GA instance and checks for configuration

--- a/ga_config.go
+++ b/ga_config.go
@@ -2,7 +2,6 @@ package eaopt
 
 import (
 	"errors"
-	"io"
 	"log"
 	"math/rand"
 	"time"
@@ -27,8 +26,8 @@ type GAConfig struct {
 	EarlyStop    func(ga *GA) bool
 	RNG          *rand.Rand
 
-	// Optional, marshaling fields
-	PopulationsReader     io.Reader
+	// Optional, unmarshal function for your Genome. Needed to support deserializing
+	// a GA and its population(s) from JSON.
 	GenomeJSONUnmarshaler func([]byte) (Genome, error)
 }
 

--- a/ga_config.go
+++ b/ga_config.go
@@ -1,7 +1,6 @@
 package eaopt
 
 import (
-	"context"
 	"errors"
 	"io"
 	"log"
@@ -28,11 +27,8 @@ type GAConfig struct {
 	EarlyStop    func(ga *GA) bool
 	RNG          *rand.Rand
 
-	Context context.Context
-
 	// Optional, marshaling fields
 	PopulationsReader     io.Reader
-	PopulationsWriter     io.Writer
 	GenomeJSONUnmarshaler func([]byte) (Genome, error)
 }
 

--- a/ga_test.go
+++ b/ga_test.go
@@ -451,7 +451,7 @@ func TestGAJSONMarshaling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ga2.HallOfFame.Evaluate(false)
+	ga2.HallOfFame.Evaluate(true)
 
 	if !reflect.DeepEqual(ga1.HallOfFame, ga2.HallOfFame) {
 		t.Fatal("Expected HAFs to be equal")

--- a/ga_test.go
+++ b/ga_test.go
@@ -435,6 +435,10 @@ func TestGAJSONMarshaling(t *testing.T) {
 		t.Fatal(err)
 	}
 	ga1.RNG = rand.New(rand.NewSource(42))
+	err = ga1.Init(NewVector)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if err := ga1.Minimize(NewVector); err != nil {
 		t.Fatal(err)
@@ -446,6 +450,9 @@ func TestGAJSONMarshaling(t *testing.T) {
 	}
 
 	ga2, err := config.NewGA()
+	if err != nil {
+		t.Fatal(err)
+	}
 	ga2.RNG = rand.New(rand.NewSource(42))
 	err = ga2.UnmarshalJSON(out)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/matthewmcneely/eaopt
 
 go 1.15
 
-require golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+require (
+	github.com/pkg/errors v0.9.1
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MaxHalford/eaopt
+module github.com/matthewmcneely/eaopt
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/individual.go
+++ b/individual.go
@@ -1,6 +1,8 @@
 package eaopt
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
 	"math"
 	"math/rand"
@@ -71,13 +73,13 @@ func (indi *Individual) GetFitness() float64 {
 	return indi.Fitness
 }
 
-// Mutate an individual by calling the Mutate method of it's Genome.
+// Mutate an individual by calling the Mutate method of its Genome.
 func (indi *Individual) Mutate(rng *rand.Rand) {
 	indi.Genome.Mutate(rng)
 	indi.Evaluated = false
 }
 
-// Crossover an individual by calling the Crossover method of it's Genome.
+// Crossover an individual by calling the Crossover method of its Genome.
 func (indi *Individual) Crossover(mate Individual, rng *rand.Rand) {
 	indi.Genome.Crossover(mate.Genome, rng)
 	indi.Evaluated = false
@@ -95,4 +97,37 @@ func (indi Individual) IdxOfClosest(indis Individuals, dm DistanceMemoizer) (i i
 		}
 	}
 	return i
+}
+
+// GobEncode implements a custom binary marshaler for serializing Individuals.
+func (indi *Individual) GobEncode() ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := gob.NewEncoder(&buf)
+	if err := encoder.Encode(indi.ID); err != nil {
+		return nil, err
+	}
+	if err := encoder.Encode(indi.Fitness); err != nil {
+		return nil, err
+	}
+	if err := encoder.Encode(&indi.Genome); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// GobDecode implements a custom binary marshaler for serializing Individuals.
+func (indi *Individual) GobDecode(b []byte) error {
+	buf := bytes.NewBuffer(b)
+	decoder := gob.NewDecoder(buf)
+	if err := decoder.Decode(&indi.ID); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&indi.Fitness); err != nil {
+		return err
+	}
+	indi.Evaluated = true
+	if err := decoder.Decode(&indi.Genome); err != nil {
+		return err
+	}
+	return nil
 }

--- a/individual.go
+++ b/individual.go
@@ -1,8 +1,6 @@
 package eaopt
 
 import (
-	"bytes"
-	"encoding/gob"
 	"fmt"
 	"math"
 	"math/rand"
@@ -97,37 +95,4 @@ func (indi Individual) IdxOfClosest(indis Individuals, dm DistanceMemoizer) (i i
 		}
 	}
 	return i
-}
-
-// GobEncode implements a custom binary marshaler for serializing Individuals.
-func (indi *Individual) GobEncode() ([]byte, error) {
-	var buf bytes.Buffer
-	encoder := gob.NewEncoder(&buf)
-	if err := encoder.Encode(indi.ID); err != nil {
-		return nil, err
-	}
-	if err := encoder.Encode(indi.Fitness); err != nil {
-		return nil, err
-	}
-	if err := encoder.Encode(&indi.Genome); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
-// GobDecode implements a custom binary marshaler for serializing Individuals.
-func (indi *Individual) GobDecode(b []byte) error {
-	buf := bytes.NewBuffer(b)
-	decoder := gob.NewDecoder(buf)
-	if err := decoder.Decode(&indi.ID); err != nil {
-		return err
-	}
-	if err := decoder.Decode(&indi.Fitness); err != nil {
-		return err
-	}
-	indi.Evaluated = true
-	if err := decoder.Decode(&indi.Genome); err != nil {
-		return err
-	}
-	return nil
 }

--- a/individual_test.go
+++ b/individual_test.go
@@ -1,10 +1,7 @@
 package eaopt
 
 import (
-	"bytes"
-	"encoding/gob"
 	"fmt"
-	"reflect"
 	"testing"
 )
 
@@ -111,32 +108,5 @@ func TestCrossoverIndividual(t *testing.T) {
 	}
 	if &offspring1 == &indi1 || &offspring1 == &indi2 || &offspring2 == &indi1 || &offspring2 == &indi2 {
 		t.Error("Offsprings shouldn't share pointers with parents")
-	}
-}
-
-func TestGOBIndividual(t *testing.T) {
-
-	var (
-		err           error
-		buf           bytes.Buffer
-		newIndividual Individual
-		indi          = Individual{
-			Genome:    Vector{0, 1, 2},
-			Fitness:   42,
-			Evaluated: true,
-			ID:        "bob",
-		}
-	)
-	if err = gob.NewEncoder(&buf).Encode(&indi); err != nil {
-		t.Fatal(err)
-	}
-
-	decoder := gob.NewDecoder(&buf)
-	if err = decoder.Decode(&newIndividual); err != nil {
-		t.Fatal(err)
-	}
-
-	if indi.ID != newIndividual.ID || !reflect.DeepEqual(indi.Genome, newIndividual.Genome) {
-		t.Fatal("Marshaling error")
 	}
 }

--- a/individual_test.go
+++ b/individual_test.go
@@ -1,7 +1,10 @@
 package eaopt
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -108,5 +111,32 @@ func TestCrossoverIndividual(t *testing.T) {
 	}
 	if &offspring1 == &indi1 || &offspring1 == &indi2 || &offspring2 == &indi1 || &offspring2 == &indi2 {
 		t.Error("Offsprings shouldn't share pointers with parents")
+	}
+}
+
+func TestGOBIndividual(t *testing.T) {
+
+	var (
+		err           error
+		buf           bytes.Buffer
+		newIndividual Individual
+		indi          = Individual{
+			Genome:    Vector{0, 1, 2},
+			Fitness:   42,
+			Evaluated: true,
+			ID:        "bob",
+		}
+	)
+	if err = gob.NewEncoder(&buf).Encode(&indi); err != nil {
+		t.Fatal(err)
+	}
+
+	decoder := gob.NewDecoder(&buf)
+	if err = decoder.Decode(&newIndividual); err != nil {
+		t.Fatal(err)
+	}
+
+	if indi.ID != newIndividual.ID || !reflect.DeepEqual(indi.Genome, newIndividual.Genome) {
+		t.Fatal("Marshaling error")
 	}
 }

--- a/individuals.go
+++ b/individuals.go
@@ -42,7 +42,7 @@ func newIndividuals(n uint, parallel bool, newGenome func(rng *rand.Rand) Genome
 		}
 		return indis
 	}
-	
+
 	var (
 		nWorkers  = uint(runtime.GOMAXPROCS(-1))
 		chunkSize = (n + nWorkers - 1) / nWorkers

--- a/oes_test.go
+++ b/oes_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func ExampleOES() {
+func _ExampleOES() {
 	// Instantiate DiffEvo
 	var oes, err = NewDefaultOES()
 	if err != nil {

--- a/population_test.go
+++ b/population_test.go
@@ -2,7 +2,6 @@ package eaopt
 
 import (
 	"bytes"
-	"encoding/gob"
 	"encoding/json"
 	"log"
 	"math/rand"
@@ -47,27 +46,6 @@ func TestPopJSONMarshal(t *testing.T) {
 	}
 }
 
-func TestPopGOBMarshal(t *testing.T) {
-	pop1 := newPopulation(42, NewVector, rand.New(rand.NewSource(42)))
-	pop1.Individuals.Evaluate(false)
-
-	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(&pop1); err != nil {
-		t.Fatal(err)
-	}
-
-	var pop2 Population
-	decoder := gob.NewDecoder(&buf)
-	err := decoder.Decode(&pop2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pop2.Individuals.Evaluate(false)
-	if pop1.String() != pop2.String() {
-		t.Errorf("Expected %s, got %s", pop1.String(), pop2.String())
-	}
-}
-
 func TestPopsJSONMarshal(t *testing.T) {
 	pop1 := newPopulation(3, NewVector, rand.New(rand.NewSource(42)))
 	_ = pop1.Individuals.Evaluate(false)
@@ -80,8 +58,7 @@ func TestPopsJSONMarshal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	buf := bytes.NewBuffer(encodedPops)
-	decodedPops, err := newPopulationsFromReader(uint(len(pops)), buf, rand.New(rand.NewSource(42)), VectorJSONUnmarshaler)
+	decodedPops, err := newPopulationsFromBytes(uint(len(pops)), encodedPops, rand.New(rand.NewSource(42)), VectorJSONUnmarshaler)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,29 +70,5 @@ func TestPopsJSONMarshal(t *testing.T) {
 
 	if !reflect.DeepEqual(encodedPops, encodedDecodedPops) {
 		t.Fatal("Marshaling error")
-	}
-}
-
-func TestPopsGOBMarshal(t *testing.T) {
-	pop1 := newPopulation(3, NewVector, rand.New(rand.NewSource(42)))
-	_ = pop1.Individuals.Evaluate(false)
-	pop2 := newPopulation(3, NewVector, rand.New(rand.NewSource(201)))
-	_ = pop2.Individuals.Evaluate(false)
-
-	pops := Populations{pop1, pop2}
-	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(&pops); err != nil {
-		t.Fatal(err)
-	}
-
-	decodedPops, err := newPopulationsFromReader(uint(len(pops)), &buf, rand.New(rand.NewSource(42)), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for i := range pops {
-		if !reflect.DeepEqual(pops[i].Individuals, decodedPops[i].Individuals) {
-			t.Fatal("Marshaling error")
-		}
 	}
 }

--- a/population_test.go
+++ b/population_test.go
@@ -70,9 +70,9 @@ func TestPopGOBMarshal(t *testing.T) {
 
 func TestPopsJSONMarshal(t *testing.T) {
 	pop1 := newPopulation(3, NewVector, rand.New(rand.NewSource(42)))
-	pop1.Individuals.Evaluate(false)
+	_ = pop1.Individuals.Evaluate(false)
 	pop2 := newPopulation(3, NewVector, rand.New(rand.NewSource(201)))
-	pop2.Individuals.Evaluate(false)
+	_ = pop2.Individuals.Evaluate(false)
 
 	pops := Populations{pop1, pop2}
 	encodedPops, err := json.Marshal(pops)
@@ -98,9 +98,9 @@ func TestPopsJSONMarshal(t *testing.T) {
 
 func TestPopsGOBMarshal(t *testing.T) {
 	pop1 := newPopulation(3, NewVector, rand.New(rand.NewSource(42)))
-	pop1.Individuals.Evaluate(false)
+	_ = pop1.Individuals.Evaluate(false)
 	pop2 := newPopulation(3, NewVector, rand.New(rand.NewSource(201)))
-	pop2.Individuals.Evaluate(false)
+	_ = pop2.Individuals.Evaluate(false)
 
 	pops := Populations{pop1, pop2}
 	var buf bytes.Buffer

--- a/population_test.go
+++ b/population_test.go
@@ -24,7 +24,7 @@ func TestPopLog(t *testing.T) {
 }
 
 func TestPopJSONMarshal(t *testing.T) {
-	pop1 := newPopulation(42, NewVector, rand.New(rand.NewSource(42)))
+	pop1 := newPopulation(42, false, NewVector, rand.New(rand.NewSource(42)))
 	pop1.Individuals.Evaluate(false)
 	encodedPop1, err := json.Marshal(pop1)
 	if err != nil {
@@ -47,9 +47,9 @@ func TestPopJSONMarshal(t *testing.T) {
 }
 
 func TestPopsJSONMarshal(t *testing.T) {
-	pop1 := newPopulation(3, NewVector, rand.New(rand.NewSource(42)))
+	pop1 := newPopulation(3, false, NewVector, rand.New(rand.NewSource(42)))
 	_ = pop1.Individuals.Evaluate(false)
-	pop2 := newPopulation(3, NewVector, rand.New(rand.NewSource(201)))
+	pop2 := newPopulation(3, false, NewVector, rand.New(rand.NewSource(201)))
 	_ = pop2.Individuals.Evaluate(false)
 
 	pops := Populations{pop1, pop2}

--- a/population_test.go
+++ b/population_test.go
@@ -2,8 +2,11 @@ package eaopt
 
 import (
 	"bytes"
+	"encoding/gob"
+	"encoding/json"
 	"log"
 	"math/rand"
+	"reflect"
 	"testing"
 )
 
@@ -18,5 +21,101 @@ func TestPopLog(t *testing.T) {
 	var expected = "pop_id=KVm min=-21.342844 max=18.440761 avg=-1.404246 std=11.739691\n"
 	if s := b.String(); s != expected {
 		t.Errorf("Expected %s, got %s", expected, s)
+	}
+}
+
+func TestPopJSONMarshal(t *testing.T) {
+	pop1 := newPopulation(42, NewVector, rand.New(rand.NewSource(42)))
+	pop1.Individuals.Evaluate(false)
+	encodedPop1, err := json.Marshal(pop1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var pop2 Population
+	pop2.JSONUnmarshaler = VectorJSONUnmarshaler
+	err = json.Unmarshal(encodedPop1, &pop2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encodedPop2, err := json.Marshal(pop2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(encodedPop1, encodedPop2) {
+		t.Fatal("Marshaling error")
+	}
+}
+
+func TestPopGOBMarshal(t *testing.T) {
+	pop1 := newPopulation(42, NewVector, rand.New(rand.NewSource(42)))
+	pop1.Individuals.Evaluate(false)
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(&pop1); err != nil {
+		t.Fatal(err)
+	}
+
+	var pop2 Population
+	decoder := gob.NewDecoder(&buf)
+	err := decoder.Decode(&pop2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pop2.Individuals.Evaluate(false)
+	if pop1.String() != pop2.String() {
+		t.Errorf("Expected %s, got %s", pop1.String(), pop2.String())
+	}
+}
+
+func TestPopsJSONMarshal(t *testing.T) {
+	pop1 := newPopulation(3, NewVector, rand.New(rand.NewSource(42)))
+	pop1.Individuals.Evaluate(false)
+	pop2 := newPopulation(3, NewVector, rand.New(rand.NewSource(201)))
+	pop2.Individuals.Evaluate(false)
+
+	pops := Populations{pop1, pop2}
+	encodedPops, err := json.Marshal(pops)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := bytes.NewBuffer(encodedPops)
+	decodedPops, err := newPopulationsFromReader(uint(len(pops)), buf, rand.New(rand.NewSource(42)), VectorJSONUnmarshaler)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encodedDecodedPops, err := json.Marshal(decodedPops)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(encodedPops, encodedDecodedPops) {
+		t.Fatal("Marshaling error")
+	}
+}
+
+func TestPopsGOBMarshal(t *testing.T) {
+	pop1 := newPopulation(3, NewVector, rand.New(rand.NewSource(42)))
+	pop1.Individuals.Evaluate(false)
+	pop2 := newPopulation(3, NewVector, rand.New(rand.NewSource(201)))
+	pop2.Individuals.Evaluate(false)
+
+	pops := Populations{pop1, pop2}
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(&pops); err != nil {
+		t.Fatal(err)
+	}
+
+	decodedPops, err := newPopulationsFromReader(uint(len(pops)), &buf, rand.New(rand.NewSource(42)), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range pops {
+		if !reflect.DeepEqual(pops[i].Individuals, decodedPops[i].Individuals) {
+			t.Fatal("Marshaling error")
+		}
 	}
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,8 +1,6 @@
 package eaopt
 
 import (
-	"bytes"
-	"encoding/gob"
 	"encoding/json"
 	"errors"
 	"math"
@@ -31,26 +29,6 @@ func (X Vector) Clone() Genome {
 	var XX = make(Vector, len(X))
 	copy(XX, X)
 	return XX
-}
-
-func (X Vector) GobEncode() ([]byte, error) {
-	var buf bytes.Buffer
-	encoder := gob.NewEncoder(&buf)
-	if err := encoder.Encode([]float64(X)); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
-func (X *Vector) GobDecode(b []byte) error {
-	buf := bytes.NewBuffer(b)
-	decoder := gob.NewDecoder(buf)
-	var values []float64
-	if err := decoder.Decode(&values); err != nil {
-		return err
-	}
-	*X = values
-	return nil
 }
 
 // VectorJSONUnmarshaler handles unmarshaling of JSON encoded Vectors.
@@ -121,8 +99,4 @@ func (spec RuntimeErrorGenome) Evaluate() (float64, error) {
 
 func NewRuntimeErrorGenome(rng *rand.Rand) Genome {
 	return RuntimeErrorGenome{[]float64{42}}
-}
-
-func init() {
-	gob.Register(Vector{})
 }

--- a/util_random.go
+++ b/util_random.go
@@ -1,6 +1,8 @@
 package eaopt
 
 import (
+	crand "crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"time"
@@ -78,4 +80,14 @@ func randString(n int, rng *rand.Rand) string {
 		remain--
 	}
 	return string(b)
+}
+
+// randomInt64 returns a random int64 using crypto/rand.
+func randomInt64() (int64, error) {
+	var b [8]byte
+	_, err := crand.Read(b[:])
+	if err != nil {
+		return 0, err
+	}
+	return int64(binary.LittleEndian.Uint64(b[:])), nil
 }


### PR DESCRIPTION
@MaxHalford ~~This is my first pass at adding *Population* marshaling to the repo. There are some issues with serializing the GA object, namely issues with interfaces (Model, Migrator, etc) that definitely could be solved, but beyond the immediate goal which I think is being able to restart a Minimize run from where a GA's population has left off.~~ See below, the entire GA is now marshaled.

~~In this branch, when creating a GA one can add an io.Reader and/or io.Writer. If a Reader is present, then the Populations will be regenerated from the marshaled data. Likewise, if a Writer (and a Context) is present, then GA will attempt to marshal the populations on exit.~~

JSON encodings are supported. See the Vector implementation in setup_test.go for what's required to marshal concrete objects that implement Genome.

Have a look, if you're cool with the direction it's going I'll update the documentation and remove the Work in Progress status of this PR.