### PR TITLE
Allow parallel initialization of individuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ type GAConfig struct {
     Model        Model
 
     // Optional fields
+	  ParallelInit bool // Whether to initialize Individuals in parallel or not
     ParallelEval bool // Whether to evaluate Individuals in parallel or not
     Migrator     Migrator
     MigFrequency uint // Frequency at which migrations occur
@@ -300,6 +301,7 @@ type GAConfig struct {
   - `HofSize` determines how many of the best individuals should be recorded.
   - `Model` is a struct that determines how to evolve each population of individuals.
 - Optional fields
+  - `ParallelInit` determines if a population is initialized in parallel. The rule of thumb is to set this to `true` if your genome initialization method is expensive, if not it won't be worth the overhead. Refer to the [section on parallelism](#a-note-on-parallelism) for a more comprehensive explanation.
   - `ParallelEval` determines if a population is evaluated in parallel. The rule of thumb is to set this to `true` if your `Evaluate` method is expensive, if not it won't be worth the overhead. Refer to the [section on parallelism](#a-note-on-parallelism) for a more comprehensive explanation.
   - `Migrator` and `MigFrequency` should be provided if you want to exchange individuals between populations in case of a multi-population GA. If not the populations will be run independently. Again this is an advanced concept in the genetic algorithms field that you shouldn't deal with at first.
   - `Speciator` will split each population in distinct species at each generation. Each specie will be evolved separately from the others, after all the species has been evolved they are regrouped.
@@ -696,7 +698,7 @@ Evolutionary algorithms are famous for being [embarrassingly parallel](https://w
 
 The Go language provides nice mechanisms to run stuff in parallel, provided you have more than one core available. However, parallelism is only worth it when the functions you want to run in parallel are heavy. If the functions are cheap then the overhead of spawning routines will be too high and not worth it. It's simply not worth using a routine for each individual because operations at an individual level are often not time consuming enough.
 
-By default eaopt will evolve populations in parallel. This is because evolving one population implies a lot of operations and parallelism is worth it. If your `Evaluate` method is heavy then it might be worth evaluating individuals in parallel, which can done by setting the `GA`'s `ParallelEval` field to `true`. Evaluating individuals in parallel can be done regardless of the fact that you are using more than one population.
+By default eaopt will evolve populations in parallel. This is because evolving one population implies a lot of operations and parallelism is worth it. If your `Evaluate` method is heavy then it might be worth evaluating individuals in parallel, which can done by setting the `GA`'s `ParallelEval` field to `true`. Evaluating individuals in parallel can be done regardless of the fact that you are using more than one population. If your genome initialization method is heavy then it might be worth initializing individuals in parallel, which can done by setting the `GA`'s `ParallelInit` field to `true`. Initializing individuals in parallel can be done regardless of the fact that you are using more than one population.
 
 
 ## FAQ

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func BenchmarkIndividualsEvaluate(b *testing.B) {
-	var indis = newIndividuals(100, NewVector, newRand())
+	var indis = newIndividuals(100, false, NewVector, newRand())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		indis.Evaluate(false)
@@ -13,7 +13,7 @@ func BenchmarkIndividualsEvaluate(b *testing.B) {
 }
 
 func BenchmarkIndividualsEvaluateParallel(b *testing.B) {
-	var indis = newIndividuals(100, NewVector, newRand())
+	var indis = newIndividuals(100, false, NewVector, newRand())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		indis.Evaluate(true)

--- a/ga.go
+++ b/ga.go
@@ -47,7 +47,7 @@ func (ga *GA) init(newGenome func(rng *rand.Rand) Genome) error {
 	// Create the initial Populations
 	ga.Populations = make(Populations, ga.NPops)
 	for i := range ga.Populations {
-		ga.Populations[i] = newPopulation(ga.PopSize, newGenome, ga.RNG)
+		ga.Populations[i] = newPopulation(ga.PopSize, ga.ParallelInit, newGenome, ga.RNG)
 		// Evaluate and sort
 		err := ga.Populations[i].Individuals.Evaluate(ga.ParallelEval)
 		if err != nil {

--- a/ga_config.go
+++ b/ga_config.go
@@ -17,6 +17,7 @@ type GAConfig struct {
 	Model        Model
 
 	// Optional fields
+	ParallelInit bool // Whether to initialize Populations in parallel or not
 	ParallelEval bool // Whether to evaluate Individuals in parallel or not
 	Migrator     Migrator
 	MigFrequency uint // Frequency at which migrations occur

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/MaxHalford/eaopt
+module github.com/qmuntal/eaopt
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/qmuntal/eaopt
+module github.com/MaxHalford/eaopt
 
 go 1.15
 

--- a/individuals.go
+++ b/individuals.go
@@ -34,11 +34,32 @@ func (indis Individuals) Clone(rng *rand.Rand) Individuals {
 }
 
 // Generate a slice of n new individuals.
-func newIndividuals(n uint, newGenome func(rng *rand.Rand) Genome, rng *rand.Rand) Individuals {
+func newIndividuals(n uint, parallel bool, newGenome func(rng *rand.Rand) Genome, rng *rand.Rand) Individuals {
 	var indis = make(Individuals, n)
-	for i := range indis {
-		indis[i] = NewIndividual(newGenome(rng), rng)
+	if !parallel {
+		for i := range indis {
+			indis[i] = NewIndividual(newGenome(rng), rng)
+		}
+		return indis
 	}
+	
+	var (
+		nWorkers  = uint(runtime.GOMAXPROCS(-1))
+		chunkSize = (n + nWorkers - 1) / nWorkers
+		g         errgroup.Group
+	)
+
+	for a := uint(0); a < n; a += chunkSize {
+		a := a // https://golang.org/doc/faq#closures_and_goroutines
+		var b = minUint(a+chunkSize, n)
+		g.Go(func() error {
+			for i := a; i < b; i++ {
+				indis[i] = NewIndividual(newGenome(rng), rng)
+			}
+			return nil
+		})
+	}
+	g.Wait()
 	return indis
 }
 

--- a/individuals.go
+++ b/individuals.go
@@ -53,8 +53,9 @@ func newIndividuals(n uint, parallel bool, newGenome func(rng *rand.Rand) Genome
 		a := a // https://golang.org/doc/faq#closures_and_goroutines
 		var b = minUint(a+chunkSize, n)
 		g.Go(func() error {
+			indRNG := rand.New(rand.NewSource(rng.Int63()))
 			for i := a; i < b; i++ {
-				indis[i] = NewIndividual(newGenome(rng), rng)
+				indis[i] = NewIndividual(newGenome(indRNG), indRNG)
 			}
 			return nil
 		})

--- a/individuals_test.go
+++ b/individuals_test.go
@@ -41,7 +41,16 @@ func TestIndividualsString(t *testing.T) {
 func TestNewIndividuals(t *testing.T) {
 	var rng = newRand()
 	for _, n := range []uint{1, 2, 42} {
-		if len(newIndividuals(n, NewVector, rng)) != int(n) {
+		if len(newIndividuals(n, false, NewVector, rng)) != int(n) {
+			t.Error("newIndividuals didn't generate the right number of individuals")
+		}
+	}
+}
+
+func TestNewIndividuals_Parallel(t *testing.T) {
+	var rng = newRand()
+	for _, n := range []uint{1, 2, 42} {
+		if len(newIndividuals(n, true, NewVector, rng)) != int(n) {
 			t.Error("newIndividuals didn't generate the right number of individuals")
 		}
 	}
@@ -50,7 +59,7 @@ func TestNewIndividuals(t *testing.T) {
 func TestCloneIndividuals(t *testing.T) {
 	var (
 		rng    = newRand()
-		indis  = newIndividuals(20, NewVector, rng)
+		indis  = newIndividuals(20, false, NewVector, rng)
 		clones = indis.Clone(rng)
 	)
 	for _, indi := range indis {
@@ -63,7 +72,7 @@ func TestCloneIndividuals(t *testing.T) {
 }
 
 func TestEvaluateIndividuals(t *testing.T) {
-	var indis = newIndividuals(10, NewVector, newRand())
+	var indis = newIndividuals(10, false, NewVector, newRand())
 	for _, indi := range indis {
 		if indi.Evaluated {
 			t.Error("Individual shouldn't have Evaluated set to True")
@@ -78,7 +87,7 @@ func TestEvaluateIndividuals(t *testing.T) {
 }
 
 func TestEvaluateIndividualsWithError(t *testing.T) {
-	var indis = newIndividuals(10, NewRuntimeErrorGenome, newRand())
+	var indis = newIndividuals(10, false, NewRuntimeErrorGenome, newRand())
 	for _, indi := range indis {
 		if indi.Evaluated {
 			t.Error("Individual shouldn't have Evaluated set to true")
@@ -95,7 +104,7 @@ func TestEvaluateIndividualsWithError(t *testing.T) {
 }
 
 func TestEvaluateIndividualsParallel(t *testing.T) {
-	var indis = newIndividuals(10, NewVector, newRand())
+	var indis = newIndividuals(10, false, NewVector, newRand())
 	for _, indi := range indis {
 		if indi.Evaluated {
 			t.Error("Individual shouldn't have Evaluated set to True")
@@ -112,7 +121,7 @@ func TestEvaluateIndividualsParallel(t *testing.T) {
 func TestMutateIndividuals(t *testing.T) {
 	var (
 		rng   = newRand()
-		indis = newIndividuals(10, NewVector, rng)
+		indis = newIndividuals(10, false, NewVector, rng)
 	)
 	indis.Evaluate(false)
 	indis.Mutate(1, rng)
@@ -124,7 +133,7 @@ func TestMutateIndividuals(t *testing.T) {
 }
 
 func TestIndividualsSortByFitness(t *testing.T) {
-	var indis = newIndividuals(10, NewVector, newRand())
+	var indis = newIndividuals(10, false, NewVector, newRand())
 	// Assign a fitness to each individual in decreasing order
 	for i := range indis {
 		indis[i].Fitness = float64(len(indis) - i)

--- a/migration_test.go
+++ b/migration_test.go
@@ -18,7 +18,7 @@ func TestMigSizes(t *testing.T) {
 				// Instantiate populations
 				var pops = make([]Population, nPops)
 				for i := range pops {
-					pops[i] = newPopulation(popSize, NewVector, rng)
+					pops[i] = newPopulation(popSize, false, NewVector, rng)
 					pops[i].Individuals.Evaluate(false)
 					fitnessMeans[i] = pops[i].Individuals.FitAvg()
 				}

--- a/models_test.go
+++ b/models_test.go
@@ -139,7 +139,7 @@ var (
 func TestGenerateOffsprings(t *testing.T) {
 	var (
 		rng   = newRand()
-		indis = newIndividuals(20, NewVector, rng)
+		indis = newIndividuals(20, false, NewVector, rng)
 	)
 	for _, n := range []uint{0, 1, 3, 10} {
 		var offsprings, _ = generateOffsprings(n, indis, SelTournament{1}, 1.0, rng)
@@ -172,7 +172,7 @@ func TestModelsConstantSize(t *testing.T) {
 	var rng = newRand()
 	for _, n := range []uint{1, 2, 3, 42} {
 		for _, model := range validModels {
-			var pop = newPopulation(n, NewVector, rng)
+			var pop = newPopulation(n, false, NewVector, rng)
 			// Check the size of the population doesn't change for a few iterations
 			for i := 0; i < 5; i++ {
 				model.Apply(&pop)

--- a/population.go
+++ b/population.go
@@ -20,11 +20,11 @@ type Population struct {
 }
 
 // Generate a new population.
-func newPopulation(size uint, newGenome func(rng *rand.Rand) Genome, rng *rand.Rand) Population {
+func newPopulation(size uint, parallel bool, newGenome func(rng *rand.Rand) Genome, rng *rand.Rand) Population {
 	var (
 		popRNG = rand.New(rand.NewSource(rng.Int63()))
 		pop    = Population{
-			Individuals: newIndividuals(size, newGenome, popRNG),
+			Individuals: newIndividuals(size, parallel, newGenome, popRNG),
 			ID:          randString(3, popRNG),
 			RNG:         popRNG,
 		}

--- a/population_test.go
+++ b/population_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestPopLog(t *testing.T) {
 	var (
-		pop    = newPopulation(42, NewVector, rand.New(rand.NewSource(42)))
+		pop    = newPopulation(42, false, NewVector, rand.New(rand.NewSource(42)))
 		b      bytes.Buffer
 		logger = log.New(&b, "", 0)
 	)

--- a/selection_test.go
+++ b/selection_test.go
@@ -19,7 +19,7 @@ var (
 func TestSelectionSize(t *testing.T) {
 	var (
 		rng       = newRand()
-		indis     = newIndividuals(30, NewVector, rng)
+		indis     = newIndividuals(30, false, NewVector, rng)
 		selectors = []Selector{
 			SelTournament{
 				NContestants: 3,
@@ -40,7 +40,7 @@ func TestSelectionSize(t *testing.T) {
 func TestSelectionUniqueness(t *testing.T) {
 	var (
 		rng       = newRand()
-		indis     = newIndividuals(3, NewVector, rng)
+		indis     = newIndividuals(3, false, NewVector, rng)
 		selectors = []Selector{
 			SelTournament{
 				NContestants: 2,
@@ -75,7 +75,7 @@ func TestSelectionUniqueness(t *testing.T) {
 func TestSelElitism(t *testing.T) {
 	var (
 		rng      = newRand()
-		indis    = newIndividuals(30, NewVector, rng)
+		indis    = newIndividuals(30, false, NewVector, rng)
 		selector = SelElitism{}
 	)
 	indis.Evaluate(false)
@@ -92,7 +92,7 @@ func TestSelElitism(t *testing.T) {
 func TestSelTournament(t *testing.T) {
 	var (
 		rng   = newRand()
-		indis = newIndividuals(30, NewVector, rng)
+		indis = newIndividuals(30, false, NewVector, rng)
 	)
 	indis.Evaluate(false)
 	var selected, _, _ = SelTournament{uint(len(indis))}.Apply(1, indis, rng)
@@ -124,7 +124,7 @@ func TestBuildWheel(t *testing.T) {
 func TestSelRoulette(t *testing.T) {
 	var (
 		rng   = newRand()
-		indis = newIndividuals(30, NewVector, rng)
+		indis = newIndividuals(30, false, NewVector, rng)
 		sel   = SelRoulette{}
 	)
 	indis.Evaluate(false)

--- a/speciation_test.go
+++ b/speciation_test.go
@@ -112,7 +112,7 @@ func TestSpecFitnessIntervalApply(t *testing.T) {
 		for _, nbs := range nSpecies {
 			var (
 				m          = minInt(int(float64(nbi/nbs)), int(nbi))
-				indis      = newIndividuals(nbi, NewVector, rng)
+				indis      = newIndividuals(nbi, false, NewVector, rng)
 				spec       = SpecFitnessInterval{K: nbs}
 				species, _ = spec.Apply(indis, rng)
 			)

--- a/util.go
+++ b/util.go
@@ -37,6 +37,14 @@ func cumsum(floats []float64) []float64 {
 	return summed
 }
 
+// Find the minimum between two uints.
+func minUint(a, b uint) uint {
+	if a <= b {
+		return a
+	}
+	return b
+}
+
 // Find the minimum between two ints.
 func minInt(a, b int) int {
 	if a <= b {


### PR DESCRIPTION
This PR adds the feature to run the individuals initialization in parallel, which can boost the performance of use cases that require heavy initialization methods.

It is implemented by adding the `GAConfig.ParallelInit`, which is `false` by default in a similar manner it is already done by `GAConfig.ParallelEval`.