### PR TITLE
Support simulated annealing

### DIFF
--- a/ga_config.go
+++ b/ga_config.go
@@ -68,7 +68,15 @@ func (conf GAConfig) NewGA() (*GA, error) {
 		}
 	}
 	// Initialize the GA
-	return &GA{GAConfig: conf}, nil
+	ga := &GA{GAConfig: conf}
+	// As a special case (and grotesque hack), point ModSimulatedAnnealing
+	// to the GA
+	if msa, ok := conf.Model.(ModSimulatedAnnealing); ok {
+		msa.GA = ga
+		ga.GAConfig.Model = msa
+	}
+	// Return the GA
+	return ga, nil
 }
 
 // NewDefaultGAConfig returns a valid GAConfig with default values.

--- a/models_test.go
+++ b/models_test.go
@@ -1,6 +1,9 @@
 package eaopt
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 var (
 	// Valid models
@@ -43,6 +46,12 @@ var (
 		},
 		ModMutationOnly{
 			Strict: true,
+		},
+		ModSimulatedAnnealing{
+			Accept: func(g, ng uint, e0, e1 float64) float64 {
+				t := 1.0 - float64(g)/float64(ng)
+				return math.Exp(-3.0 * t)
+			},
 		},
 	}
 	// Invalid models
@@ -131,6 +140,7 @@ var (
 			Selector: SelTournament{1},
 			MutRate:  -1,
 		},
+		ModSimulatedAnnealing{},
 	}
 )
 


### PR DESCRIPTION
This pull request introduces a `ModSimulatedAnnealing` model, which is a generalization of `ModMutationOnly`.  Instead of a `Strict` Boolean argument, `ModSimulatedAnnealing` takes an `Accept` function, which returns a probability from 0.0 (never accept a worse fitness—like `Strict: true`) to 1.0 (always accept a worse fitness—like `Strict: false`).  A typical `Accept` function is likely to accept worse fitness values early in the evolution but unlikely to do so later in the evolution.

One caveat with the implementation is that `ModSimulatedAnnealing` needs access to both `GAConfig.NGenerations` and `GA.Generations`.  Unfortunately, models are selected before a `GAConfig` and a `GA` have been created.  The workaround implemented by this pull request is to add a special case to `NewGA` that detects a `ModSimulatedAnnealing` model and updates it with a pointer to the `GA` that it is about to return.
