### PR TITLE
Mutate at least one element in differential evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ func NewSPSO(nParticles, nSteps uint, min, max, w float64, parallel bool, rng *r
 
 #### Example
 
-In this example we're going to minimize th [Ackley function](https://www.sfu.ca/~ssurjano/ackley.html) with two dimensions. The global minimum is 0.
+In this example we're going to minimize the [Ackley function](https://www.sfu.ca/~ssurjano/ackley.html) with two dimensions. The global minimum is 0.
 
 ```go
 package main
@@ -591,7 +591,7 @@ func main() {
 This should produce the following output.
 
 ```sh
->>> Found minimum of 0.00137, the global minimum is 0
+>>> Found minimum of 0.00001, the global minimum is 0
 ```
 
 #### Parameters

--- a/README.md
+++ b/README.md
@@ -537,8 +537,6 @@ func NewSPSO(nParticles, nSteps uint, min, max, w float64, parallel bool, rng *r
 
 [Differential evolution (DE)](https://www.wikiwand.com/en/Differential_evolution) somewhat resembles PSO and is also used for optimizing real-valued functions. At each generation, each so-called agent is moved according to the position of 3 randomly sampled agents. If the new position is not better than the current one then it is discarded.
 
-As can be expected there are many variants of PSO. The `SPSO` struct implements the [SPSO-2011 standard](http://clerc.maurice.free.fr/pso/SPSO_descriptions.pdf).
-
 #### Example
 
 In this example we're going to minimize th [Ackley function](https://www.sfu.ca/~ssurjano/ackley.html) with two dimensions. The global minimum is 0.

--- a/diff_evo.go
+++ b/diff_evo.go
@@ -20,8 +20,9 @@ func (a Agent) Evaluate() (float64, error) {
 // Mutate the Agent.
 func (a *Agent) Mutate(rng *rand.Rand) {
 	var agents = a.DE.sampleAgents(3, rng)
+	var mustChange = rng.Intn(len(a.x))
 	for i := range a.x {
-		if rng.Float64() < a.DE.CRate {
+		if i == mustChange || rng.Float64() < a.DE.CRate {
 			a.x[i] = agents[0].x[i] + a.DE.DWeight*(agents[1].x[i]-agents[2].x[i])
 		}
 	}

--- a/diff_evo_test.go
+++ b/diff_evo_test.go
@@ -43,7 +43,7 @@ func ExampleDiffEvo() {
 	// Output best encountered solution
 	fmt.Printf("Found minimum of %.5f in %v\n", y, x)
 	// Output:
-	// Found minimum of 0.00137 in [0.0004420129693826938 0.000195924625132926]
+	// Found minimum of 0.00001 in [4.732587024307115e-06 1.1630296709345484e-06]
 }
 
 func TestAgentCrossover(t *testing.T) {


### PR DESCRIPTION
This pull request forces the mutation of at least one element per differential-evolution agent each generation.

Differential evolution randomly decides based on the crossover rate whether to modify each individual element of an agent vector.  For low crossover rates it is likely that an agent is left unmodified, which wastes computation as the agent is guaranteed not to improve.  The solution is to choose an element index at random and ensure that that index changes.  See, for example, [Wikipedia](https://en.wikipedia.org/wiki/Differential_evolution) and [Qiang and Mitchell (2014)](https://www.osti.gov/servlets/purl/1163659).

The benefit of this pull request is evidenced by `ExampleDiffEvo`'s minimization of the [Ackley function](https://www.sfu.ca/~ssurjano/ackley.html), which should have a minimum of 0.0 at (0.0, 0.0):

**Before**: Found minimum of 0.00137 in [0.0004420129693826938 0.000195924625132926]
**After**: Found minimum of 0.00001 in [4.732587024307115e-06 1.1630296709345484e-06]